### PR TITLE
Corrected mismatched POM properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <junit.version>4.12</junit.version>
         <java.version>1.8</java.version>
         <surefire.version>2.22.2</surefire.version>
@@ -128,8 +128,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
At some point, the maven.compiler.* properties got out of sync with the actual compiler configuration. This should now be fixed, and it works on my machine, but make sure to test the build!